### PR TITLE
build error fix

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import Document, { DocumentContext } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
@@ -13,11 +14,11 @@ export default class DocumentWithStyledComponents extends Document {
       return {
         ...initialProps,
         styles: [
-          <>
+          <Fragment key="styled-components-insert">
             {initialProps.styles}
             {sheet.getStyleElement()}
             <link rel="stylesheet" href="https://use.typekit.net/wwx1oja.css" />
-          </>,
+          </Fragment>,
         ],
       }
     } finally {


### PR DESCRIPTION
This fixes an issue where build would report error: “Each child in a list should have a unique ‘key’ prop.” 