### PR TITLE
Social Login Component

### DIFF
--- a/src/components/Layout/Header/ProcessingSocialLoginShelf/ProcessingSocialLoginShelf.stories.tsx
+++ b/src/components/Layout/Header/ProcessingSocialLoginShelf/ProcessingSocialLoginShelf.stories.tsx
@@ -1,0 +1,9 @@
+import ProcessingSocialLoginShelf from './'
+
+export default {
+  title: 'header/ProcessingSocialLoginShelf',
+  component: ProcessingSocialLoginShelf,
+  argTypes: {},
+}
+
+export const ProcessingSocialLoginShelfComponent = (props: any) => <ProcessingSocialLoginShelf {...props} />

--- a/src/components/Layout/Header/ProcessingSocialLoginShelf/ProcessingSocialLoginShelf.test.tsx
+++ b/src/components/Layout/Header/ProcessingSocialLoginShelf/ProcessingSocialLoginShelf.test.tsx
@@ -1,0 +1,9 @@
+import renderer from 'react-test-renderer'
+import ProcessingSocialLoginShelf from './'
+
+describe('ProcessingSocialLoginShelf', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<ProcessingSocialLoginShelf />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/Layout/Header/ProcessingSocialLoginShelf/index.tsx
+++ b/src/components/Layout/Header/ProcessingSocialLoginShelf/index.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components'
+import { Spinner, Icon } from '@components'
+import { typography, breakpoint } from '@theme'
+
+const ProcessingSocialLoginShelf = () => {
+  return (
+    <Wrapper>
+      <Copy>
+        <Headline>Finishing social login</Headline>
+        <InfoRow>
+          <Icon glyph="infoLarge" outline level={1} />
+          <SignInDirections>This will only take a moment…</SignInDirections>
+        </InfoRow>
+      </Copy>
+      <Processing>
+        <Spinner />
+      </Processing>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  @media only screen and (min-width: ${breakpoint.tablet}px) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: 'copy processing';
+    gap: 10px;
+  }
+`
+
+const Copy = styled.div`
+  grid-area: copy;
+`
+
+const Headline = styled.h1`
+  ${typography.title.l2};
+`
+
+const InfoRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin: 1em 0 2em 0;
+  @media only screen and (min-width: ${breakpoint.laptop}px) {
+    margin: 1em 0 0 0;
+  }
+`
+
+const SignInDirections = styled.p`
+  ${typography.label.l1};
+`
+
+const Processing = styled.div`
+  position: relative;
+  grid-area: processing;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+export default ProcessingSocialLoginShelf

--- a/src/components/Layout/Header/SessionShelf/SessionShelf.stories.tsx
+++ b/src/components/Layout/Header/SessionShelf/SessionShelf.stories.tsx
@@ -1,7 +1,7 @@
 import SessionShelf from './'
 
 export default {
-  title: 'components/SessionShelf',
+  title: 'header/SessionShelf',
   component: SessionShelf,
   argTypes: {},
 }

--- a/src/components/Layout/Header/SessionShelf/index.tsx
+++ b/src/components/Layout/Header/SessionShelf/index.tsx
@@ -1,22 +1,47 @@
-import { useState } from 'react'
-import { useReactiveVar, useQuery } from '@apollo/client'
-import { userMetadataVar } from '@lib'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { useApolloClient, useReactiveVar, useQuery } from '@apollo/client'
+import { userMetadataVar, finishSocialLogin, useMagic } from '@lib'
 import { GET_USER } from '@gql'
 import { IGetUserQuery, IUser } from '@types'
 import LoginShelf from '../LoginShelf'
 import AccountShelf from '../AccountShelf'
+import ProcessingSocialLoginShelf from '../ProcessingSocialLoginShelf'
+import { ShelfType } from '../'
 
-const SessionShelf = () => {
+interface ISessionShelf {
+  setVisibleShelf: React.Dispatch<React.SetStateAction<ShelfType | undefined>>
+}
+
+const SessionShelf = ({ setVisibleShelf }: ISessionShelf) => {
+  const { query } = useRouter()
+  const { magic } = useMagic()
+  const apolloClient = useApolloClient()
+
   const metadata = useReactiveVar(userMetadataVar)
   const [loggedInUser, setLoggedInUser] = useState<IUser>()
   useQuery<IGetUserQuery>(GET_USER, {
     variables: { issuer: metadata?.issuer },
-    onCompleted: data => {
-      setLoggedInUser(data.User[0] as IUser)
-    },
+    onCompleted: data => setLoggedInUser(data.User[0] as IUser),
   })
 
-  return !!metadata && !!loggedInUser ? <AccountShelf user={loggedInUser} /> : <LoginShelf />
+  const [loadingSocialLogin, setLoadingSocialLogin] = useState<boolean>(false)
+  useEffect(() => {
+    if (!magic) throw 'Error: magic is not initialized.'
+    if (!query.provider) return
+    setLoadingSocialLogin(true)
+    setVisibleShelf('session')
+    // Send token to server to validate
+    finishSocialLogin(apolloClient, magic)
+  }, [query, magic])
+
+  return !!metadata && !!loggedInUser ? (
+    <AccountShelf user={loggedInUser} />
+  ) : loadingSocialLogin ? (
+    <ProcessingSocialLoginShelf />
+  ) : (
+    <LoginShelf />
+  )
 }
 
 export default SessionShelf

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -10,7 +10,7 @@ import Shelf from './Shelf'
 import { breakpoint, palette, glyphKey } from '@theme'
 import { rgba } from '@lib'
 
-type ShelfType = 'session' | 'howItWorks' | 'donate'
+export type ShelfType = 'session' | 'howItWorks' | 'donate'
 
 const Header = () => {
   const [shadowVisible, setShadowVisible] = useState(false)
@@ -56,7 +56,7 @@ const Header = () => {
         </Items>
       </Wrapper>
       <Shelf visible={visibleShelf === 'session'} hideShelf={() => toggleShelf()} {...{ shadowVisible }}>
-        <SessionShelf />
+        <SessionShelf {...{ setVisibleShelf }} />
       </Shelf>
       <Shelf visible={visibleShelf === 'howItWorks'} hideShelf={() => toggleShelf()} {...{ shadowVisible }}>
         <HowItWorks />

--- a/src/lib/session/createSession.ts
+++ b/src/lib/session/createSession.ts
@@ -1,25 +1,9 @@
-import { OAuthProvider } from '@magic-ext/oauth'
 import { ApolloClient } from '@apollo/client'
 import { userMetadataVar } from '@lib'
 import { GET_USER } from '@gql'
 import { IGetUserQuery } from '@types'
 
-async function handleLoginWithEmail(magic: MagicInstance, email: string) {
-  const didToken = await magic.auth.loginWithMagicLink({ email, showUI: false })
-  if (!didToken) throw 'Error retrieving token with email'
-  return didToken
-}
-
-const createSession = async (apolloClient: ApolloClient<object>, magic: MagicInstance, email: string) => {
-  if (!email) {
-    throw 'Error: one of email'
-  }
-
-  const didToken = await handleLoginWithEmail(magic, email)
-
-  // const didToken = email ?  : await handleLoginWithSocial(magic, provider!)
-  // TODO: remove non-null assertion as part of social refactor ^
-
+export const createSession = async (apolloClient: ApolloClient<object>, didToken: string) => {
   const apiData = await fetch('/api/createSession', {
     method: 'POST',
     headers: {
@@ -37,5 +21,3 @@ const createSession = async (apolloClient: ApolloClient<object>, magic: MagicIns
   const { data } = await apolloClient.query<IGetUserQuery>({ query: GET_USER, variables: { issuer: metadata.issuer } })
   if (data.User.length < 1) throw 'Error retrieving user'
 }
-
-export { createSession }

--- a/src/lib/session/finishSocialLogin.ts
+++ b/src/lib/session/finishSocialLogin.ts
@@ -4,5 +4,5 @@ import { createSession } from '@lib'
 export const finishSocialLogin = async (apolloClient: ApolloClient<object>, magic: MagicInstance) => {
   const result = await magic.oauth.getRedirectResult()
   await createSession(apolloClient, result.magic.idToken)
-  document.location = '/'
+  document.location.reload()
 }

--- a/src/lib/session/finishSocialLogin.ts
+++ b/src/lib/session/finishSocialLogin.ts
@@ -1,0 +1,8 @@
+import type { ApolloClient } from '@apollo/client'
+import { createSession } from '@lib'
+
+export const finishSocialLogin = async (apolloClient: ApolloClient<object>, magic: MagicInstance) => {
+  const result = await magic.oauth.getRedirectResult()
+  await createSession(apolloClient, result.magic.idToken)
+  document.location = '/'
+}

--- a/src/lib/session/index.ts
+++ b/src/lib/session/index.ts
@@ -1,3 +1,5 @@
-export * from './login'
+export * from './createSession'
+export * from './finishSocialLogin'
+export * from './loginWithEmail'
 export * from './logout'
 export * from './refreshSession'

--- a/src/lib/session/loginWithEmail.ts
+++ b/src/lib/session/loginWithEmail.ts
@@ -1,0 +1,8 @@
+import { ApolloClient } from '@apollo/client'
+import { createSession } from '@lib'
+
+export const loginWithEmail = async (apolloClient: ApolloClient<object>, magic: MagicInstance, email: string) => {
+  const didToken = await magic.auth.loginWithMagicLink({ email, showUI: false })
+  if (!didToken) throw 'Error retrieving token with email'
+  createSession(apolloClient, didToken)
+}

--- a/src/pages/api/onramp/order.ts
+++ b/src/pages/api/onramp/order.ts
@@ -19,7 +19,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const body = {
     delivery: {
-      // eslint-disable-next-line camelcase
       payment_method_token: paymentMethodToken,
       url: `${process.env.SENDRYRE_BASE_URL}/v3/debitcard/process/partner`,
       headers: `Content-Type: application/json\r\nAuthorization: Bearer ${process.env.SENDWYRE_SECRET}`,


### PR DESCRIPTION
- moved social login initiator from index page to `SessionShelf.tsx` (was already the hub for session initiation logic)
- finishSocialLogin.ts now shares code with email login as per todo
- new component displays "finishing social login" as per todo