### PR TITLE
hasura env var name change and minor grant changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .next",
     "generate": "node ./tools/generate.js",
     "dev": "SECRET_ENV=DevSecrets op run --no-masking --env-file='.env.local' -- next dev",
-    "develop": "yarn codegen && next dev",
+    "develop": "yarn codegen-local && next dev",
     "build": "yarn codegen && next build",
     "start": "next build && next start -p $PORT",
     "lint": "next lint",

--- a/src/lib/apollo/apolloClient.ts
+++ b/src/lib/apollo/apolloClient.ts
@@ -25,7 +25,7 @@ export const createApolloClient = (didToken?: string) => {
     const newHeaders: Record<string, string> = {}
     if (isServer() && !didToken) {
       // server request (usually for SSR)
-      newHeaders['x-hasura-admin-secret'] = assert(process.env.HASURA_ADMIN_SECRET, 'HASURA_ADMIN_SECRET')
+      newHeaders['x-hasura-admin-secret'] = assert(process.env.HASURA_GRAPHQL_ADMIN_SECRET, 'HASURA_GRAPHQL_ADMIN_SECRET')
     } else if (isServer() && didToken) {
       // server request on behalf of user via MagicLink DecentralizedID token
       newHeaders['Authorization'] = `Bearer ${didToken}`

--- a/src/lib/apollo/apolloClient.ts
+++ b/src/lib/apollo/apolloClient.ts
@@ -25,7 +25,10 @@ export const createApolloClient = (didToken?: string) => {
     const newHeaders: Record<string, string> = {}
     if (isServer() && !didToken) {
       // server request (usually for SSR)
-      newHeaders['x-hasura-admin-secret'] = assert(process.env.HASURA_GRAPHQL_ADMIN_SECRET, 'HASURA_GRAPHQL_ADMIN_SECRET')
+      newHeaders['x-hasura-admin-secret'] = assert(
+        process.env.HASURA_GRAPHQL_ADMIN_SECRET,
+        'HASURA_GRAPHQL_ADMIN_SECRET',
+      )
     } else if (isServer() && didToken) {
       // server request on behalf of user via MagicLink DecentralizedID token
       newHeaders['Authorization'] = `Bearer ${didToken}`

--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -6,7 +6,7 @@ import { mockGrants } from './mock-grants'
 
 export const useGrant = () => {
   const { address } = useAccount()
-  const { data: signer } = useSigner()
+  const { data: signer, isError, isLoading } = useSigner()
 
   const nftContractAddress = assert(process.env.NEXT_PUBLIC_NFT_CONTRACT_ADDRESS, 'NEXT_PUBLIC_NFT_CONTRACT_ADDRESS')
   const grantContractAddress = assert(
@@ -147,7 +147,7 @@ export const useGrant = () => {
 
   const donate = async (grantId: number, amount: string) => {
     // console.log('it gets here', ethers.utils.parseUnits('1', 'ether'))
-    const grantTransaction = await grantsContract.donate(9, ethers.utils.parseEther(amount), {
+    const grantTransaction = await grantsContract.donate(1, ethers.utils.parseEther(amount), {
       value: ethers.utils.parseEther(amount),
     })
     await grantTransaction.wait()

--- a/src/lib/utilsServer/queryHasura.ts
+++ b/src/lib/utilsServer/queryHasura.ts
@@ -32,13 +32,13 @@ export const queryHasura = async (query: any, token: string) => {
 
 export const queryHasuraAsAdmin = async (query: any) => {
   try {
-    const HASURA_ADMIN_SECRET = assert(process.env.HASURA_ADMIN_SECRET, 'HASURA_ADMIN_SECRET')
+    const HASURA_GRAPHQL_ADMIN_SECRET = assert(process.env.HASURA_GRAPHQL_ADMIN_SECRET, 'HASURA_GRAPHQL_ADMIN_SECRET')
     const HASURA_GRAPHQL_URL = assert(process.env.NEXT_PUBLIC_HASURA_GRAPHQL_URL, 'NEXT_PUBLIC_HASURA_GRAPHQL_URL')
 
     const headers = new Headers()
     headers.set('Content-Type', 'application/json')
     headers.set('Accept', 'application/json')
-    headers.set('x-hasura-admin-secret', HASURA_ADMIN_SECRET)
+    headers.set('x-hasura-admin-secret', HASURA_GRAPHQL_ADMIN_SECRET)
     const res = await fetch(HASURA_GRAPHQL_URL, {
       method: 'POST',
       headers,

--- a/tools/graphql-codegen.yml
+++ b/tools/graphql-codegen.yml
@@ -2,7 +2,7 @@ overwrite: true
 schema:
   - ${NEXT_PUBLIC_HASURA_GRAPHQL_URL}:
       headers:
-        'x-hasura-admin-secret': ${HASURA_ADMIN_SECRET}
+        'x-hasura-admin-secret': ${HASURA_GRAPHQL_ADMIN_SECRET}
 documents: 'src/gql/*.ts'
 generates:
   src/types/generated.ts:


### PR DESCRIPTION
I've updated secrets as outlined in trello

@rubelux note I changed `HASURA_ADMIN_SECRET` to `HASURA_GRAPHQL_ADMIN_SECRET` (to align with naming convention on hasura cloud) and I also set the grant number to 1 for donations to align with recently deployed contract on goerli. We should refactor out this hardcoded value asap 👍 

cc @EricWVGG 