### PR TITLE
change startingDate and endTime timestamps from ms to seconds

### DIFF
--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -168,7 +168,7 @@ export const useGrant = () => {
     console.log('grant.startTime   ', grant.startingDate)
     console.log('grant.closingDate   ', grant.closingDate)
 
-    // EK TESTING: 
+    // EK TESTING:
     // Date.now() returns current time in *milliseconds* since epoch
     // I believe that startTime and endTime timestamps on contract should be in seconds
     // please confirm with Z

--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -168,12 +168,18 @@ export const useGrant = () => {
     console.log('grant.startTime   ', grant.startingDate)
     console.log('grant.closingDate   ', grant.closingDate)
 
-    const startingDate = Date.now()
+    // EK TESTING: 
+    // Date.now() returns current time in *milliseconds* since epoch
+    // I believe that startTime and endTime timestamps on contract should be in seconds
+    // please confirm with Z
+    // => THIS DOES ALLOW sendRewards to be called
+    const startingDate = Math.floor(Date.now() / 1000)
     const endTime = (Number(startingDate) + 60 * 10).toString()
 
     console.log('grant starting time', startingDate)
     console.log('grant  endTime', endTime)
 
+    // COMPARE ABOVE WITH EXISTING COMMENT BELOW ON startTime
     const grantTuple = {
       nftContract: nftContractAddress,
       nftOwner: address,

--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -57,9 +57,9 @@ export const useGrant = () => {
     const inpactTags = grant.submission?.project?.impactTags?.split(',') || []
 
     const leadMemberTraitType = project?.members.map(({ user, type }) => {
-      console.log('user type, ', type === 'leader')
+      console.log('user type, ', type === 'lead')
       console.log('user user, ', `${user?.firstName} ${user?.lastName}`)
-      if (type === 'leader') {
+      if (type === 'lead') {
         return `${user?.firstName} ${user?.lastName}`
       }
       return null


### PR DESCRIPTION
@Cryptogirlx @rubelux (and FYI @EricWVGG to check ts math functions pls)

This is a fix in order to allow `Grants.sendRewards` to be called on the grant published from the web2 admin form.

The issue is that `Date.now()` returns the time *in milliseconds* since the epoch, but the `startTime` and `endTime` values on the grant in the contract must be in seconds.

I tested this on goerli and here is [the transaction for the tested sendRewards call](https://goerli.etherscan.io/tx/0x6184c729e3fd8e892c3d75f4feb72cb766f3498dcfec42c45d2347a339f60981)

