### PR TITLE
fixing Artifact ordering upstream and propagating changes to useGrant.ts

### DIFF
--- a/src/components/CreateGrants/NewGrantForm/lib/mapArtifacts.ts
+++ b/src/components/CreateGrants/NewGrantForm/lib/mapArtifacts.ts
@@ -8,7 +8,15 @@ export type MappedArtifact = {
 
 export const mapArtifactF = (artifactsData: Artifacts): Array<MappedArtifact> => {
   // TODO: This should be break down into smaller units
+  // The ordering is specified here
+  // https://docs.google.com/document/d/1Jwsmc3WxCK_Z-uRCjLNhTp8EbJGSF0CT7MNDbg0jmQk/edit
+  // Creator, Community, Patron
   return [
+    {
+      edition: 'creator',
+      artwork: artifactsData.artworkCreator,
+      video: artifactsData.videoCreator,
+    },
     {
       edition: 'community',
       artwork: artifactsData.artworkCommunity,
@@ -18,11 +26,6 @@ export const mapArtifactF = (artifactsData: Artifacts): Array<MappedArtifact> =>
       edition: 'patron',
       artwork: artifactsData.artworkPatron,
       video: artifactsData.videoCommunity,
-    },
-    {
-      edition: 'creator',
-      artwork: artifactsData.artworkCreator,
-      video: artifactsData.videoCreator,
     },
   ]
 }

--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -42,17 +42,17 @@ export const useGrant = () => {
     return response.json()
   }
 
-  const minNFTs = async (grant: IGrantsWithProjectFragment) => {
+  const mintNFTs = async (grant: IGrantsWithProjectFragment) => {
     //map artifacts data
 
     if (!grant.submission) {
-      throw new Error('Grant cannot be pubish because it is missing submission')
+      throw new Error('Grant cannot be published because it is missing submission')
     }
 
     const { artifacts } = grant.submission
     const { project } = grant.submission
     const members = grant.submission?.project?.members
-    const inpactTags = grant.submission?.project?.impactTags?.split(',') || []
+    const impactTags = grant.submission?.project?.impactTags?.split(',') || []
 
     const leadMemberTraitType = members?.map(({ user, type }) => {
       console.log('user type, ', type === 'lead')
@@ -82,16 +82,11 @@ export const useGrant = () => {
     // NOTE: index must be aligned with the published NFTs on chain!
     const metadataUris = artifacts.map(async (artifact, index) => {
       const latestTokenId: BigNumber = await nftContract.getCurrentTokenId()
-      // TODO: once Artifact ordering has stabilized for good, consider fixing this upstream
-      //       => an upstream change would also affect at least the construction of grantTuple below
-      // using (3 - index) here because the minted Artifact order is:
+      // The minted Artifact order is:
       //     1. Creator
       //     2. Community
       //     3. Patron
-      // for index = 0, 1, 2,
-      // (index + 1) becomes 1, 2, 3 (previous attempt at fixing this numbering)
-      // (3 - index) becomes 3, 2, 1 (which is the reverse of the previous attempt, which is what we want)
-      const artifactNumber = latestTokenId.add(3 - index) // can't + a BigNumber and a Number, so need to .add()...
+      const artifactNumber = latestTokenId.add(index + 1) // can't + a BigNumber and a Number, so need to .add()...
       const artifactName = `Artifact #${artifactNumber}`
       const artifactDescription = `**${artifactName} minted by "${project.title}"**
 *${artifact.edition} Edition 1/1*
@@ -129,7 +124,7 @@ This Artifact is in the [public domain](https://creativecommons.org/publicdomain
           { trait_type: 'Project', value: project.title },
 
           { trait_type: 'Lead Creator', value: leadMemberTraitType },
-          ...inpactTags.map(tag => {
+          ...impactTags.map(tag => {
             return { trait_type: 'Impact', value: tag }
           }),
         ],
@@ -180,9 +175,8 @@ This Artifact is in the [public domain](https://creativecommons.org/publicdomain
 
   const publish = async (grant: IGrantsWithProjectFragment) => {
     // const grant = mockGrants[0]
-    const metadataUris = await minNFTs(grant)
-
-    console.log('IPFS metadataUris     ', metadataUris)
+    const metadataUris = await mintNFTs(grant)
+    console.log(`metadataUris = ${metadataUris}`)
 
     if (!metadataUris) {
       throw new Error('Non metadataUris from NFTs publish')


### PR DESCRIPTION
Improvements for metadata artifact numbering-- fixes the primary issue upstream (in `mapArtifacts.ts`) and makes appropriate changes in `useGrant.ts`. Tested locally and works as expected.

Note for @rubelux : this does * not * fix the token ID async issue. I wanted to get these metadata fixes in asap to merge and pay down some tech debt asap, and in the meantime I'll continue looking at the async token ID issue.