### PR TITLE
leaderboard fix

### DIFF
--- a/src/components/Leaderboard/index.tsx
+++ b/src/components/Leaderboard/index.tsx
@@ -85,10 +85,10 @@ const Leaderboard = ({ grantId, setAmountRaised }: ILeaderboard) => {
         reduceWithPrecision(usersWithAggregate.map(d => d.aggregateDonation))((a: number, b: number) => a + b),
       )
     }
-    if (!loggedInUser) return
-    //    const i = usersWithAggregate.filter(user => user.publicAddress === loggedInUser.publicAddress)[0].aggregateDonation
+    if (!loggedInUser || usersWithAggregate.length < 1) return
     setLoggedUserDonation(
-      usersWithAggregate.filter(user => user.publicAddress === loggedInUser.publicAddress)[0].aggregateDonation,
+      usersWithAggregate.filter(user => user.publicAddress === loggedInUser.publicAddress)[0]?.aggregateDonation ||
+        undefined,
     )
   }, [data])
 


### PR DESCRIPTION
This fixes the leaderboard when there's no donations present. (Unsure if it'll render correctly if there *are* donations, but not including the logged in user… we'll see…)