### PR TITLE
potential fix for token id vs metadata issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ yarn-error.log*
 .env.test.local
 .env.production
 .env.production.*
-
+.env*vercel
 
 # vercel
 .vercel

--- a/src/lib/useGrant.ts
+++ b/src/lib/useGrant.ts
@@ -165,11 +165,28 @@ This Artifact is in the [public domain](https://creativecommons.org/publicdomain
         }),
       )
 
-      const mintTransaction = await nftContract.safeMint(address, `ipfs://${metadata.IpfsHash}`)
-      await mintTransaction.wait()
+      const ipfsUri = `ipfs://${metadata.IpfsHash}`
+      console.log(`ipfsUri: ${ipfsUri}`)
 
-      return true
+      return ipfsUri
     })
+
+    console.log('before first safe mint')
+
+    const mintTransaction0 = await nftContract.safeMint(address, metadataUris[0])
+    await mintTransaction0.wait()
+
+    console.log('before second safe mint')
+
+    const mintTransaction1 = await nftContract.safeMint(address, metadataUris[1])
+    await mintTransaction1.wait()
+
+    console.log('before third safe mint')
+
+    const mintTransaction2 = await nftContract.safeMint(address, metadataUris[2])
+    await mintTransaction2.wait()
+
+    console.log('after last safe mint')
 
     return Promise.all(metadataUris)
   }


### PR DESCRIPTION
@rubelux I've tested this via localhost and it queues up the safeMint transactions one at a time in the correct order in metamask

essentially i moved the safeMint calls outside of the map-- previously the map was building the metadata and calling safeMint.